### PR TITLE
analyse partial GA save files

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -49,7 +49,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = dbconn.loadSession('2018-03-12 08:14:44')"
+    "data = dbconn.loadSession('2018-03-12 08:14:44')\n",
+    "print('loaded data:{}'.format(data.keys()))"
    ]
   },
   {

--- a/db/databaseconnection.py
+++ b/db/databaseconnection.py
@@ -87,22 +87,25 @@ class DatabaseConnection:
 		gaSession = self.dbSession.query(Sessions).filter(Sessions.sessionId == sessionId).first()
 		data = {}
 
-		data['metrics'] = gaSession.sessionMetrics.metricsPickle
+		if gaSession.sessionMetrics:
+			data['metrics'] = gaSession.sessionMetrics.metricsPickle
 
-		data['genealogy'] = {}
-		data['genealogy']['tree'] = gaSession.sessionGenealogy.treePickle
-		data['genealogy']['history'] = gaSession.sessionGenealogy.historyPickle
+		if gaSession.sessionGenealogy:
+			data['genealogy'] = {}
+			data['genealogy']['tree'] = gaSession.sessionGenealogy.treePickle
+			data['genealogy']['history'] = gaSession.sessionGenealogy.historyPickle
 
-		data['individuals'] = []
-		for sessionIndividual in gaSession.sessionIndividuals:
-			individual = {}
-			individual['gen'] = sessionIndividual.gen
-			individual['ind'] = sessionIndividual.ind
-			individual['fitness'] = sessionIndividual.fitness
-			individual['genome'] = sessionIndividual.genomePickle
-			individual['phenome'] = sessionIndividual.phenomePickle
+		if gaSession.sessionIndividuals:
+			data['individuals'] = []
+			for sessionIndividual in gaSession.sessionIndividuals:
+				individual = {}
+				individual['gen'] = sessionIndividual.gen
+				individual['ind'] = sessionIndividual.ind
+				individual['fitness'] = sessionIndividual.fitness
+				individual['genome'] = sessionIndividual.genomePickle
+				individual['phenome'] = sessionIndividual.phenomePickle
 
-			data['individuals'].append(individual)
+				data['individuals'].append(individual)
 
 		return data
 


### PR DESCRIPTION
when a GA session is stopped mid-run, the save file contains data about the individuals (but not the metrics, genealogy which are only saved at the end of the GA run). 

this just checks metrics/genealogy/individuals exist in the save file before attempting to load them for the analysis notebook, so it'll now load partial save files with only information about individuals just fine.  