### PR TITLE
adjustments to model

### DIFF
--- a/membranesimulation.py
+++ b/membranesimulation.py
@@ -20,7 +20,7 @@ class MembraneSimulation():
 		scripttemplate, 
 		corepos_x=0, 
 		corepos_y=0, 
-		corepos_z=7, 
+		corepos_z=6.5, 
 		dumpres="100",
 		rAxis = [0,0,1],
 		rAmount = 0.0

--- a/nanoparticle.py
+++ b/nanoparticle.py
@@ -6,7 +6,7 @@ from tools import icosatiler
 import numpy as np
 
 class Ligand:
-	def __init__(self,eps,sig,rad,polAng,aziAng,mass=1,cutoff=2.0):
+	def __init__(self,eps,sig,rad,polAng,aziAng,mass=1,cutoff=1.8):
 		self.rad = rad
 		self.polAng = polAng
 		self.aziAng = aziAng


### PR DESCRIPTION
- NP starts slightly closer to membrane (from 7 to 6.5) to help make sure 1. rotations before reaching membrane further minimised, 2. try prevent any NPs from floating away from membrane and not being evaluated
- ligand interaction range is slightly shorter (2.0 to 1.8), 1.8 to accommodate high affinity ligands. membrane behaves weirdly if high affinity + longer int. range (membrane 'crawling' up the NP). 2.0 is fine for low affinity ligands usually