### PR TITLE
Fix/lammps cluster tweak

### DIFF
--- a/mem/template/in.template
+++ b/mem/template/in.template
@@ -23,7 +23,7 @@ variable	theta0_11	equal	0
 
 variable memsize equal "count(mem)"
 #compute 1 all pair lj/cut epair
-compute cls all cluster/atom 1.5
+compute cls mem cluster/atom ${rmin}
 compute ct all temp/sphere
 compute_modify ct extra ${memsize}
 

--- a/run.py
+++ b/run.py
@@ -290,7 +290,7 @@ def evaluateNPWrapping(np,outFilename,runtime):
 
             nLargeClusters = 0
             for v in sorted(cStep, key=itemgetter('size')):
-                if v['size'] > 100:
+                if v['size'] > 250:
                     nLargeClusters += 1
             budded = nLargeClusters > 1
                                        


### PR DESCRIPTION
1. decrease clustering distance to 1.122462 (the max range of the membrane self-assembly interaction). trying to prevent budded-in but too close to the mother membrane so not picked up. also clustering only membrane beads (add another clustering if we're replacing python bead count with lammps?)
2. increased min size for 'large clusters' slightly (roughly matches the min fitness score for membrane deformation before the NP buds in)