### PR TITLE
fix gen counting

### DIFF
--- a/ga/networkedgeneticalgorithm.py
+++ b/ga/networkedgeneticalgorithm.py
@@ -34,7 +34,7 @@ creator.create("Individual", numpy.ndarray, fitness=creator.FitnessMax) # @Undef
 
 def defaultAlgorithmEaSimple(pop,toolbox,stats,hof):
 		return algorithms.eaSimple(pop,toolbox=toolbox,
-		cxpb=0.5, mutpb=0.2, ngen=5,verbose=False,stats=stats,halloffame=hof)
+		cxpb=0.5, mutpb=0.2, ngen=1,verbose=False,stats=stats,halloffame=hof)
 
 def defaultTwoPoint(ind1, ind2):
     size = len(ind1)

--- a/run.py
+++ b/run.py
@@ -581,7 +581,7 @@ def mut(individual):
 
 def algorithmEaSimple(pop,toolbox,stats,hof,verbose=VERBOSE):
     return algorithms.eaSimple(pop,toolbox=toolbox,
-        cxpb=CXPB, mutpb=MUTPB, ngen=FREQ,verbose=verbose,stats=stats,halloffame=hof)
+        cxpb=CXPB, mutpb=MUTPB, ngen=1,verbose=verbose,stats=stats,halloffame=hof)
 
 def commitSession(ga):
     novelGenes = []


### PR DESCRIPTION
generation counting breaks if migration frequency =/= 1 in current code. since the looping over generations in the function run() in networkedgeneticalgorithm.py goes generation by generation (0,1,2,3...), the call to the GA algo (eaSimple) should always ask to only run 1 generation.