### PR TITLE
fixed simnames

### DIFF
--- a/ga/phenome.py
+++ b/ga/phenome.py
@@ -1,5 +1,6 @@
 from . import grayencoder as ge
 import hashlib
+from tools import misctools
 
 class Phenome:
 	def __init__(self,ind):
@@ -22,5 +23,5 @@ class Phenome:
 		return None
 
 	def makeUniqueId(self,ind):
-		return hashlib.sha1(ind).hexdigest()
+		return hashlib.sha1(ind).hexdigest() + "_" + misctools.randomStr(5)
 

--- a/run.py
+++ b/run.py
@@ -637,7 +637,7 @@ def evaluateParticle(np,simName):
 def evaluate(individual):
     phenome = CoveredNanoParticlePhenome(individual,EXPRPLACES,EPSPLACES,EPSMIN,EPSMAX) if not PARTIAL else NanoParticlePhenome(individual,EXPRPLACES,EPSPLACES,POLANGPLACES,AZIANGPLACES,EPSMIN,EPSMAX)
     np = phenome.particle    
-    simName = phenome.id + "_" + misctools.randomStr(10)
+    simName = phenome.id
     r = evaluateParticle(np,simName)
     if SAVERESULTS:
         with open(os.path.join(OUTDIR,simName+'.pickle'), 'wb') as handle:

--- a/run.py
+++ b/run.py
@@ -636,8 +636,8 @@ def evaluateParticle(np,simName):
 
 def evaluate(individual):
     phenome = CoveredNanoParticlePhenome(individual,EXPRPLACES,EPSPLACES,EPSMIN,EPSMAX) if not PARTIAL else NanoParticlePhenome(individual,EXPRPLACES,EPSPLACES,POLANGPLACES,AZIANGPLACES,EPSMIN,EPSMAX)
-    np = phenome.particle
-    simName = phenome.id
+    np = phenome.particle    
+    simName = phenome.id + "_" + misctools.randomStr(10)
     r = evaluateParticle(np,simName)
     if SAVERESULTS:
         with open(os.path.join(OUTDIR,simName+'.pickle'), 'wb') as handle:


### PR DESCRIPTION
simnames are currently done based on a hash of the ind object. however, the same ind object can exist within the same generation (presenting a problem during vanilla GA runs) and can also exist over the course of an entire GA run (presenting a problem if saving all output). or maybe i misunderstood how the hashes work!